### PR TITLE
Use nix develop and cargo test for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,10 @@ jobs:
       - uses: DeterminateSystems/nix-installer-action@main
       - uses: DeterminateSystems/magic-nix-cache-action@main
       - run: nix flake check
-  build:
+  cargo-test:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - uses: DeterminateSystems/nix-installer-action@main
       - uses: DeterminateSystems/magic-nix-cache-action@main
-      - run: nix build -j auto
+      - run: nix develop --command cargo test


### PR DESCRIPTION
Nix build builds the project twice when we only really have to build once to run tests. This has the bonus effect of testing the devShell in the flake.